### PR TITLE
set SDKDIR when using VS10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ VISUALSTUDIODIR = $(wildcard /cygdrive/c/Program*Files/Microsoft*Visual*Studio*8
 SDKDIR = $(wildcard /cygdrive/c/Program*Files/Microsoft*SDKs/Windows/*/Lib)
 ifeq (,$(VISUALSTUDIODIR))
 VISUALSTUDIODIR = $(wildcard /cygdrive/c/Program\ Files\ */Microsoft*Visual*Studio*10*)
+SDKDIR = $(wildcard /cygdrive/c/Program*Files*/Microsoft*SDKs/Windows/*/Lib)
 endif
 ifeq (,$(VISUALSTUDIODIR))
 VISUALSTUDIODIR = $(wildcard /cygdrive/c/Program\ Files\ */Microsoft*Visual*Studio*11*)


### PR DESCRIPTION
also change glob to Program_Files_ to include "Program Files (x86)"

completes fixes for #7
