### PR TITLE
Update misc.c

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -92,7 +92,7 @@ vlocerrorexit(const char *filename, unsigned int linenum,
         const char *format, va_list ap)
 {
     if (filename)
-        fprintf(stderr, linenum ? "%s: %i: " : "%s: ", filename, linenum);
+        linenum ? fprintf(stderr, "%s: %i: ", filename, linenum) : fprintf(stderr, "%s: ", filename);
     vfprintf(stderr, format, ap);
     fputc('\n', stderr);
     exit(1);


### PR DESCRIPTION
Line 96:
 fprintf(stderr, linenum ? "%s: %i: " : "%s: ", filename, linenum);
will cause compilation on osx to fail with:
cc -g -Wall -Werror -O2  -Iobj -oobj/misc.o -c src/misc.c
src/misc.c:95:66: error: data argument not used by format string [-Werror,-Wformat-extra-args]
        fprintf(stderr, linenum ? "%s: %i: " : "%s: ", filename, linenum);

Proposing change to:
 linenum ? fprintf(stderr, "%s: %i: ", filename, linenum) : fprintf(stderr, "%s: ", filename);
