### PR TITLE
removed static pointer arithmatic to fix compile error on osx

### DIFF
--- a/src/comment.c
+++ b/src/comment.c
@@ -1615,10 +1615,16 @@ checkforlineofstars:
                 pos = strchr(match, ch);
                 if (pos) {
                     /* Got a \ escape sequence. */
-                    const char *text = 
-                        "\\\0    @\0    &amp;\0$\0    #\0    &lt;\0 >\0    %"
-                        + 6 * (pos - match);
-                    cnode = addtext(cnode, text, strlen(text));
+				    const char *text[] = { "\\",
+										   "@",
+										   "&amp;",
+										   "$",
+										   "#",
+										   "&lt;"
+										   ">"
+										   "%" };
+					
+                    cnode = addtext(cnode, text[pos-match], strlen(text[pos-match]));
                     p += 2;
                     ch = *p;
                     starttext = p;

--- a/src/process.c
+++ b/src/process.c
@@ -39,6 +39,7 @@ static const char ntnames[] = { NTNAMES };
 void
 printtext(const char *s, unsigned int len, int escamp)
 {
+    const int tabLen = 8; // must be 8 or less 
     const char *p = s, *end = s + len;
     unsigned int count = 0;
     while (p != end) {
@@ -61,8 +62,10 @@ printtext(const char *s, unsigned int len, int escamp)
             count = 0;
             continue;
         case '\t':
-            seq = "        " + ((count - 1) & 7);
-            count = 0;
+		    memset( buf, ' ', sizeof(buf) );
+			buf[ 8 - ((count - 1) % tabLen ) ] = 0;
+			seq = buf;
+            count += 8 - ((count - 1) % tabLen);
             break;
         default:
             if ((unsigned char)ch >= 0x20) {


### PR DESCRIPTION

There were two trivial things that would not compile for me on osx. This could be fixed just using the same pointer arithmetic on separate lines if you want but this seemed a bit clearer to me. 